### PR TITLE
Add config option to specify the path to place the generated nginx configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ an array:
 As you can see, this allows you to define which port to connect to
 instead of the default port (which is port 80).
 
+### Specifying the NGINX configuration file path
+
+If you want to change the location of the managed nginx configuration file, set the `config.reverse_proxy.nginx_config_file` value to a path on your host machine in the Vagrantfile configuration:
+
+    config.reverse_proxy.nginx_config_file = '/usr/local/etc/nginx/vagrant-proxy-config'
 
 ## Adding proxy support to your application
 

--- a/lib/vagrant-reverse-proxy/config.rb
+++ b/lib/vagrant-reverse-proxy/config.rb
@@ -2,12 +2,13 @@ module VagrantPlugins
   module ReverseProxy
     class Plugin
       class Config < Vagrant.plugin(2, :config)
-        attr_accessor :enabled, :vhosts
+        attr_accessor :enabled, :vhosts, :nginx_config_file
         alias_method :enabled?, :enabled
 
         def initialize
           @enabled = UNSET_VALUE
           @vhosts = UNSET_VALUE
+          @nginx_config_file = UNSET_VALUE
         end
 
         def finalize!
@@ -28,6 +29,9 @@ module VagrantPlugins
                 value[:port] ||= 80
               end
             end
+          end
+          if @nginx_config_file == UNSET_VALUE
+            @nginx_config_file = nil
           end
         end
 
@@ -59,6 +63,10 @@ module VagrantPlugins
             end
           elsif @vhosts != nil && @vhosts != UNSET_VALUE
             errors << 'vhosts must be an array of hostnames, a string=>string hash or nil'
+          end
+
+          unless @nginx_config_file.instance_of?(String) || @nginx_config_file == nil || @nginx_config_file == UNSET_VALUE
+            errors << 'nginx_config_file must be a string'
           end
 
           { 'Reverse proxy configuration' => errors.compact }


### PR DESCRIPTION
Hi,

Great plugin - solves the exact problem I am currently facing at work. One initial problem I had using it was that when installing NGINX on my host laptop (macOS) via Homebrew, the default install path was `/usr/local/etc/nginx`, and not `/etc/nginx`.

This PR adds an optional configuration option to specify this path, defaulting to the current `/etc/nginx`.

I'm not a Ruby dev but hopefully everything is okay with the code...