### PR TITLE
Add ability for the nginx reload command to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ If you want to change the location of the managed nginx configuration file, set 
 
 ### Specifying the NGINX reload command
 
-After the NGINX configuration file is generated, a reload command is executed so that the changes take affect. By default the command executed is `sudo service nginx reload`. If you need to change this, set the `config.reverse_proxy.nginx_reload_command` option to the command to be executed:
+After the NGINX configuration file is generated, a reload command is executed so that the changes take effect. By default the command executed is `sudo nginx -s reload`. If you need to change this, set the `config.reverse_proxy.nginx_reload_command` option to the command to be executed:
 
-    config.reverse_proxy.nginx_reload_command = 'sudo nginx -s reload'
+    config.reverse_proxy.nginx_reload_command = 'sudo service nginx reload'
 
 ## Adding proxy support to your application
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ If you want to change the location of the managed nginx configuration file, set 
 
     config.reverse_proxy.nginx_config_file = '/usr/local/etc/nginx/vagrant-proxy-config'
 
+### Specifying the NGINX reload command
+
+After the NGINX configuration file is generated, a reload command is executed so that the changes take affect. By default the command executed is `sudo service nginx reload`. If you need to change this, set the `config.reverse_proxy.nginx_reload_command` option to the command to be executed:
+
+    config.reverse_proxy.nginx_reload_command = 'sudo nginx -s reload'
+
 ## Adding proxy support to your application
 
 This plugin will instruct NGINX to pass the following headers to your

--- a/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
+++ b/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
@@ -70,7 +70,7 @@ module VagrantPlugins
           Kernel.system('sudo', 'cp', tmp_file.to_s, nginx_config_file)
 
           # And reload nginx
-          nginx_reload_command = env[:machine].config.reverse_proxy.nginx_reload_command || 'sudo service nginx reload'
+          nginx_reload_command = env[:machine].config.reverse_proxy.nginx_reload_command || 'sudo nginx -s reload'
           Kernel.system(nginx_reload_command)
         end
 

--- a/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
+++ b/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
@@ -66,9 +66,12 @@ module VagrantPlugins
             end
           end
 
-          # Finally, copy tmp config to actual config and reload nginx
+          # Finally, copy tmp config to actual config
           Kernel.system('sudo', 'cp', tmp_file.to_s, nginx_config_file)
-          Kernel.system('sudo', 'service', 'nginx', 'reload')
+
+          # And reload nginx
+          nginx_reload_command = env[:machine].config.reverse_proxy.nginx_reload_command || 'sudo service nginx reload'
+          Kernel.system(nginx_reload_command)
         end
 
         def server_block(machine)

--- a/lib/vagrant-reverse-proxy/config.rb
+++ b/lib/vagrant-reverse-proxy/config.rb
@@ -2,13 +2,14 @@ module VagrantPlugins
   module ReverseProxy
     class Plugin
       class Config < Vagrant.plugin(2, :config)
-        attr_accessor :enabled, :vhosts, :nginx_config_file
+        attr_accessor :enabled, :vhosts, :nginx_config_file, :nginx_reload_command
         alias_method :enabled?, :enabled
 
         def initialize
           @enabled = UNSET_VALUE
           @vhosts = UNSET_VALUE
           @nginx_config_file = UNSET_VALUE
+          @nginx_reload_command = UNSET_VALUE
         end
 
         def finalize!
@@ -32,6 +33,9 @@ module VagrantPlugins
           end
           if @nginx_config_file == UNSET_VALUE
             @nginx_config_file = nil
+          end
+          if @nginx_reload_command == UNSET_VALUE
+            @nginx_reload_command = nil
           end
         end
 
@@ -67,6 +71,10 @@ module VagrantPlugins
 
           unless @nginx_config_file.instance_of?(String) || @nginx_config_file == nil || @nginx_config_file == UNSET_VALUE
             errors << 'nginx_config_file must be a string'
+          end
+
+          unless @nginx_reload_command.instance_of?(String) || @nginx_reload_command == nil || @nginx_reload_command == UNSET_VALUE
+            errors << 'nginx_reload_command must be a string'
           end
 
           { 'Reverse proxy configuration' => errors.compact }


### PR DESCRIPTION
My final obstacle with using this plugin with a Homebrew install of NGINX on macOS is that the a different command is needed to reload NGINX.

This PR brings in another optional config value for the command. 