### PR TITLE
re-generate the nginx configuration on Vagrant reload, fix README error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ proxy to port 80 on the virtual machine with a `config.vm.hostname`
 value of `foo`.  This is only done for virtual machines that have
 `config.reverse_proxy.enabled` set to `true` in their config.
 
-Whenever you bring up or halt a machine, the plugin updates the proxy
-config file and invokes `sudo systemctl reload nginx` to make the
+Whenever you bring up, halt, or reload a machine, the plugin updates the proxy
+config file and invokes `sudo nginx -s reload` to make the
 change immediately visible.
 
 ### Custom host names

--- a/lib/vagrant-reverse-proxy/plugin.rb
+++ b/lib/vagrant-reverse-proxy/plugin.rb
@@ -32,6 +32,10 @@ module VagrantPlugins
       action_hook(:reverse_proxy, :machine_action_halt) do |hook|
         hook.append(Action.remove_machine)
       end
+
+      action_hook(:reverse_proxy, :machine_action_reload) do |hook|
+        hook.append(Action.add_machine)
+      end
     end
   end
 end


### PR DESCRIPTION
Sorry, got another PR for you...

I noticed the plugin doesn't re-generate the configuration on `vagrant reload`, which I believe is used for bringing in `Vagrantfile` changes.

Also fixed a doc error introduced in my last PR where I didn't update an instance of the nginx reload command.