### PR TITLE
Generate server block configuration as well as location, fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you don't need anything specific, just put the following in
 
     server {
         listen 80 default;
-        listen [::]:80 default ipv6only=off;
+        listen [::]:80 default;
         # This is the fallback server
         server_name default;
         # Redirect http://localhost/hostname/lalala

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install the plugin as usual:
 
 First, install NGINX and create a configuration as usual.  Then, in
 the `server` configuration block for the host you want to use for
-proxying, simply put `include "vagrant-proxy-config";` in the file.
+proxying, simply put `include "vagrant-proxy-config-locations";` in the file.
 
 If you don't need anything specific, just put the following in
 `/etc/nginx/sites-enabled/default`:
@@ -36,7 +36,7 @@ If you don't need anything specific, just put the following in
         server_name default;
         # Redirect http://localhost/hostname/lalala
         # to http://hostname/lalala
-        include "vagrant-proxy-config";
+        include "vagrant-proxy-config-locations";
     }
 
 This will load the `/etc/nginx/vagrant-proxy-config` file which is
@@ -46,9 +46,20 @@ proxy to port 80 on the virtual machine with a `config.vm.hostname`
 value of `foo`.  This is only done for virtual machines that have
 `config.reverse_proxy.enabled` set to `true` in their config.
 
+#### Server Blocks
+
+The plugin also writes `server` block configuration for the enabled VMs so that they can be
+accessed directly via their hostname (as long as the hostname resolves to the host machine's I.P address).
+
+To include these, simply include the generated file inside your main nginx `http` block:
+
+    http {
+        include "vagrant-proxy-config-servers";
+    }
+
+
 Whenever you bring up, halt, or reload a machine, the plugin updates the proxy
-config file and invokes `sudo nginx -s reload` to make the
-change immediately visible.
+config files and invokes `sudo nginx -s reload` to make the change immediately visible.
 
 ### Custom host names
 
@@ -72,11 +83,14 @@ an array:
 As you can see, this allows you to define which port to connect to
 instead of the default port (which is port 80).
 
-### Specifying the NGINX configuration file path
+### Specifying the NGINX configuration file paths
 
-If you want to change the location of the managed nginx configuration file, set the `config.reverse_proxy.nginx_config_file` value to a path on your host machine in the Vagrantfile configuration:
+If you want to change the location of the managed nginx configuration files, set the `config.reverse_proxy.nginx_locations_config_file` or `config.reverse_proxy.nginx_servers_config_file` values to paths on your host machine in the Vagrantfile configuration:
 
-    config.reverse_proxy.nginx_config_file = '/usr/local/etc/nginx/vagrant-proxy-config'
+    config.reverse_proxy.nginx_locations_config_file = '/usr/local/etc/nginx/vagrant-proxy-config-locations'
+    config.reverse_proxy.nginx_servers_config_file = '/usr/local/etc/nginx/vagrant-proxy-config-servers'
+
+If you don't want to generate one of the locations or server configuration files, set the appropriate config value to `nil`.
 
 ### Specifying the NGINX reload command
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you don't need anything specific, just put the following in
 `/etc/nginx/sites-enabled/default`:
 
     server {
+        listen 80 default;
         listen [::]:80 default ipv6only=off;
         # This is the fallback server
         server_name default;
@@ -49,7 +50,7 @@ value of `foo`.  This is only done for virtual machines that have
 #### Server Blocks
 
 The plugin also writes `server` block configuration for the enabled VMs so that they can be
-accessed directly via their hostname (as long as the hostname resolves to the host machine's I.P address).
+accessed directly via their hostname (as long as the hostname resolves to the host machine's IP address).
 
 To include these, simply include the generated file inside your main nginx `http` block:
 

--- a/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
+++ b/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
@@ -15,20 +15,48 @@ module VagrantPlugins
           # be removed.
           return unless env[:machine].config.reverse_proxy.enabled?
 
-          # Determine temp file and target file
-          nginx_config_file = env[:machine].config.reverse_proxy.nginx_config_file || '/etc/nginx/vagrant-proxy-config'
+          # Determine the filepaths for the locations config file. Give a default if not set.
+          if env[:machine].config.reverse_proxy.nginx_locations_config_file == VagrantPlugins::ReverseProxy::Plugin::Config::UNSET_VALUE
+            nginx_locations_config_file = '/etc/nginx/vagrant-proxy-config-locations'
+          else
+            nginx_locations_config_file = env[:machine].config.reverse_proxy.nginx_locations_config_file
+          end
 
-          # Get the directory of the config file
-          nginx_config_dir = File.dirname(nginx_config_file)
+          # Determine the filepaths for the servers config file. Give a default if not set.
+          if env[:machine].config.reverse_proxy.nginx_servers_config_file == VagrantPlugins::ReverseProxy::Plugin::Config::UNSET_VALUE
+            nginx_servers_config_file = '/etc/nginx/vagrant-proxy-config-servers'
+          else
+            nginx_servers_config_file = env[:machine].config.reverse_proxy.nginx_servers_config_file
+          end
 
-          unless File.directory?(nginx_config_dir)
-            env[:ui].error("Could not update nginx configuration: directory '#{nginx_config_dir}' does not exist.  Continuing without proxy...")
+          env[:ui].info('Updating nginx configuration. Administrator privileges will be required...')
+
+          # Generate the locations config file if not set to nil
+          if nginx_locations_config_file
+            generate_config_file(env, nginx_locations_config_file, location_block(env[:machine]))
+          end
+
+          # Generate the servers config file if not set to nil
+          if nginx_servers_config_file
+            generate_config_file(env, nginx_servers_config_file, server_block(env[:machine]))
+          end
+
+          # And reload nginx
+          nginx_reload_command = env[:machine].config.reverse_proxy.nginx_reload_command || 'sudo nginx -s reload'
+          Kernel.system(nginx_reload_command)
+        end
+
+        def generate_config_file(env, file_to_write_to, config_block)
+
+          # Get the directory of the file being written to
+          file_dir = File.dirname(file_to_write_to)
+
+          unless File.directory?(file_dir)
+            env[:ui].error("Could not update nginx configuration file '#{file_to_write_to}' : directory '#{file_dir}' does not exist. Continuing...")
             return
           end
 
           tmp_file = env[:machine].env.tmp_path.join('nginx.vagrant-proxies')
-
-          env[:ui].info('Updating nginx configuration. Administrator privileges will be required...')
 
           sm = start_marker(env[:machine])
           em = end_marker(env[:machine])
@@ -39,7 +67,7 @@ module VagrantPlugins
           # changed, and might not have been present originally.
           File.open(tmp_file, 'w') do |new|
             begin
-              File.open(nginx_config_file, 'r') do |old|
+              File.open(file_to_write_to, 'r') do |old|
                 # First, remove old entries for this machine.
                 while ln = old.gets() do
                   if sm == ln.chomp
@@ -61,20 +89,17 @@ module VagrantPlugins
             if @action == :add # Removal is already (always) done above
               # Write the config for this machine
               if env[:machine].config.reverse_proxy.enabled?
-                new.write(sm+"\n"+server_block(env[:machine])+em+"\n")
+                new.write(sm+"\n"+config_block+em+"\n")
               end
             end
           end
 
           # Finally, copy tmp config to actual config
-          Kernel.system('sudo', 'cp', tmp_file.to_s, nginx_config_file)
+          Kernel.system('sudo', 'cp', tmp_file.to_s, file_to_write_to)
 
-          # And reload nginx
-          nginx_reload_command = env[:machine].config.reverse_proxy.nginx_reload_command || 'sudo nginx -s reload'
-          Kernel.system(nginx_reload_command)
         end
 
-        def server_block(machine)
+        def location_block(machine)
           if machine.config.reverse_proxy.vhosts
             vhosts = machine.config.reverse_proxy.vhosts
           else
@@ -92,10 +117,43 @@ location /#{path}/ {
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Base-Url http://$host:$server_port/#{path}/;
 
     proxy_pass http://#{ip}#{port_suffix}/;
     proxy_redirect http://#{vhost[:host]}#{port_suffix}/ /#{path}/;
+}
+EOF
+          end.join("\n")
+        end
+
+        def server_block(machine)
+          if machine.config.reverse_proxy.vhosts
+            vhosts = machine.config.reverse_proxy.vhosts
+          else
+            host = machine.config.vm.hostname || machine.name
+            vhosts = {host => host}
+          end
+          ip = get_ip_address(machine)
+          vhosts.collect do |path, vhost|
+            # Rewrites are matches literally by nginx, which means
+            # http://host:80/... will NOT match http://host/...!
+            port_suffix = vhost[:port] == 80 ? '' : ":#{vhost[:port]}"
+            <<EOF
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name #{vhost[:host]};
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://#{ip}#{port_suffix}/;
+    }
 }
 EOF
           end.join("\n")

--- a/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
+++ b/lib/vagrant-reverse-proxy/action/write_nginx_config.rb
@@ -15,19 +15,9 @@ module VagrantPlugins
           # be removed.
           return unless env[:machine].config.reverse_proxy.enabled?
 
-          # Determine the filepaths for the locations config file. Give a default if not set.
-          if env[:machine].config.reverse_proxy.nginx_locations_config_file == VagrantPlugins::ReverseProxy::Plugin::Config::UNSET_VALUE
-            nginx_locations_config_file = '/etc/nginx/vagrant-proxy-config-locations'
-          else
-            nginx_locations_config_file = env[:machine].config.reverse_proxy.nginx_locations_config_file
-          end
-
-          # Determine the filepaths for the servers config file. Give a default if not set.
-          if env[:machine].config.reverse_proxy.nginx_servers_config_file == VagrantPlugins::ReverseProxy::Plugin::Config::UNSET_VALUE
-            nginx_servers_config_file = '/etc/nginx/vagrant-proxy-config-servers'
-          else
-            nginx_servers_config_file = env[:machine].config.reverse_proxy.nginx_servers_config_file
-          end
+          # Get the filepaths for the config files.
+          nginx_locations_config_file = env[:machine].config.reverse_proxy.nginx_locations_config_file
+          nginx_servers_config_file = env[:machine].config.reverse_proxy.nginx_servers_config_file
 
           env[:ui].info('Updating nginx configuration. Administrator privileges will be required...')
 
@@ -143,10 +133,13 @@ EOF
             <<EOF
 server {
     listen 80;
+    listen [::]:80;
     listen 443 ssl;
-    server_name #{vhost[:host]};
+    listen [::]:443 ssl;
+
+    server_name #{path};
     location / {
-        proxy_set_header Host $host;
+        proxy_set_header Host #{vhost[:host]};
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;

--- a/lib/vagrant-reverse-proxy/config.rb
+++ b/lib/vagrant-reverse-proxy/config.rb
@@ -2,13 +2,14 @@ module VagrantPlugins
   module ReverseProxy
     class Plugin
       class Config < Vagrant.plugin(2, :config)
-        attr_accessor :enabled, :vhosts, :nginx_config_file, :nginx_reload_command
+        attr_accessor :enabled, :vhosts, :nginx_locations_config_file, :nginx_servers_config_file, :nginx_reload_command
         alias_method :enabled?, :enabled
 
         def initialize
           @enabled = UNSET_VALUE
           @vhosts = UNSET_VALUE
-          @nginx_config_file = UNSET_VALUE
+          @nginx_locations_config_file = UNSET_VALUE
+          @nginx_servers_config_file = UNSET_VALUE
           @nginx_reload_command = UNSET_VALUE
         end
 
@@ -30,9 +31,6 @@ module VagrantPlugins
                 value[:port] ||= 80
               end
             end
-          end
-          if @nginx_config_file == UNSET_VALUE
-            @nginx_config_file = nil
           end
           if @nginx_reload_command == UNSET_VALUE
             @nginx_reload_command = nil
@@ -69,8 +67,16 @@ module VagrantPlugins
             errors << 'vhosts must be an array of hostnames, a string=>string hash or nil'
           end
 
-          unless @nginx_config_file.instance_of?(String) || @nginx_config_file == nil || @nginx_config_file == UNSET_VALUE
-            errors << 'nginx_config_file must be a string'
+          unless @nginx_locations_config_file.instance_of?(String) || @nginx_locations_config_file == nil || @nginx_locations_config_file == UNSET_VALUE
+            errors << 'nginx_locations_config_file must be a string'
+          end
+
+          unless @nginx_servers_config_file.instance_of?(String) || @nginx_servers_config_file == nil || @nginx_servers_config_file == UNSET_VALUE
+            errors << 'nginx_servers_config_file must be a string'
+          end
+
+          if @nginx_locations_config_file == nil && @nginx_servers_config_file == nil
+            errors << 'only one of nginx_locations_config_file and nginx_servers_config_file can be nil'
           end
 
           unless @nginx_reload_command.instance_of?(String) || @nginx_reload_command == nil || @nginx_reload_command == UNSET_VALUE

--- a/lib/vagrant-reverse-proxy/config.rb
+++ b/lib/vagrant-reverse-proxy/config.rb
@@ -32,6 +32,12 @@ module VagrantPlugins
               end
             end
           end
+          if @nginx_location_config_file == UNSET_VALUE
+            @nginx_location_config_file = '/etc/nginx/vagrant-proxy-config-locations'
+          end
+          if @nginx_servers_config_file == UNSET_VALUE
+            @nginx_servers_config_file = '/etc/nginx/vagrant-proxy-config-servers'
+          end
           if @nginx_reload_command == UNSET_VALUE
             @nginx_reload_command = nil
           end

--- a/lib/vagrant-reverse-proxy/config.rb
+++ b/lib/vagrant-reverse-proxy/config.rb
@@ -32,8 +32,8 @@ module VagrantPlugins
               end
             end
           end
-          if @nginx_location_config_file == UNSET_VALUE
-            @nginx_location_config_file = '/etc/nginx/vagrant-proxy-config-locations'
+          if @nginx_locations_config_file == UNSET_VALUE
+            @nginx_locations_config_file = '/etc/nginx/vagrant-proxy-config-locations'
           end
           if @nginx_servers_config_file == UNSET_VALUE
             @nginx_servers_config_file = '/etc/nginx/vagrant-proxy-config-servers'


### PR DESCRIPTION
This PR gives the plugin the ability to generate server block location as well as location blocks, with the option to set one to `nil` to not generate - fixes #5.